### PR TITLE
Get only flights

### DIFF
--- a/data-prep.qmd
+++ b/data-prep.qmd
@@ -41,13 +41,12 @@ laxflights2022raw <- read_csv("data-raw/laxflights2022raw.csv", show_col_types =
 If you are having issues with downloading this data all at once then you can split up the download into smaller chunks like so:
 
 ```r
-laxflights1 <- anyflights("LAX", 2022, 1:6)
-laxflights2 <- anyflights("LAX", 2022, 7:12)
-
+laxflights1 <- get_flights("LAX", 2022, 1:6)
+laxflights2 <- get_flights("LAX", 2022, 7:12)
 
 laxflights2022raw <- dplyr::bind_rows(
-  laxflights1$flights,
-  laxflights2$flights
+  laxflights1,
+  laxflights2
 )
 ```
 :::


### PR DESCRIPTION
The download for a whole year at once already uses `get_flights()` instead of `anyflight()`. So I've adapted the section of breaking it up since it's consistent and extra nice to not download anything beyond the flights in the context of a possibly flaky internet connection.